### PR TITLE
don't read the name as a list

### DIFF
--- a/pnt/sipot/obligacion.py
+++ b/pnt/sipot/obligacion.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
         + RESET_COLOR,
     )
 
-    parser.add_argument("--nombreSujeto", type=list, help="Nombre de Sujeto")
+    parser.add_argument("--nombreSujeto", type=str, help="Nombre de Sujeto")
 
     parser.add_argument("--colaboradora", type=str, help="Nombre de la colaboradora")
     parser.add_argument(


### PR DESCRIPTION
El nombre se usa solo para mensajes y para crear un nombre de archivo. Parece ser que cuando es un solo sujeto este nombre se interpreta mal como una lista de caracteres. Me parece que esto lo resuelve. Hice pruebas en local con uno y dos sujetos y parece que funciona.