### PR TITLE
Manejo de rutas

### DIFF
--- a/sisai/sisai/scrapingArchivosSISAI.py
+++ b/sisai/sisai/scrapingArchivosSISAI.py
@@ -5,16 +5,18 @@
 #######################################################
 #######################################################
 
+from time import sleep
+from pathlib import Path
 import json
 import logging
-from time import sleep
+import os
+import random
 import time
+
 import pandas as pd
 import asyncio
 import nest_asyncio
 from playwright.async_api import async_playwright, Browser
-import os
-import random
 from playwright._impl._errors import Error as PlaywrightError
 from playwright._impl._errors import TimeoutError
 
@@ -47,7 +49,7 @@ nest_asyncio.apply()
 class ScrapingDataFrame:
     def __init__(
         self,
-        file_path: str,
+        file_path: Path,
         sem: int | None,
         downloads_path: str | None,
     ):
@@ -56,7 +58,7 @@ class ScrapingDataFrame:
         self.downloads_path = (
             downloads_path
             if downloads_path is not None
-            else f"archivo_adjunto_sisai_{file_path.replace('.json','')}"
+            else f"archivo_adjunto_sisai_{file_path.stem}"
         )
         self.column_name = "archivo_adjunto"
         self.index = self.load_state()
@@ -64,7 +66,7 @@ class ScrapingDataFrame:
     def load_state(self) -> int:
         try:
             with open(
-                f"state_index_SISAI_{self.file_path.replace('.json','')}.json", "r"
+                f"state_index_SISAI_{self.file_path.stem}.json", "r"
             ) as f:
                 state = json.load(f)
                 return state["index"]
@@ -74,7 +76,7 @@ class ScrapingDataFrame:
     def save_state(self) -> int:
         state = {"index": self.index}
         with open(
-            f"state_index_SISAI_{self.file_path.replace('.json','')}.json", "w"
+            f"state_index_SISAI_{self.file_path.stem}.json", "w"
         ) as f:
             json.dump(state, f)
 
@@ -205,7 +207,7 @@ class ScrapingDataFrame:
         #######################################################
         #######################################################
 
-        df = pd.read_json(f"{self.file_path}", lines=True)
+        df = pd.read_json(self.file_path, lines=True)
 
         if self.column_name not in df.columns:
             raise ValueError(

--- a/sisai/solicitudes.py
+++ b/sisai/solicitudes.py
@@ -1,4 +1,6 @@
 import argparse
+from pathlib import Path
+
 from sisai.scrapingArchivosSISAI import ScrapingDataFrame
 
 
@@ -8,7 +10,7 @@ def main():
     )
     parser.add_argument(
         "file_path",
-        type=str,
+        type=Path,
         help="La ruta al archivo que desea procesar. Este archivo debe ser un JSON con registros SISAI.",
     )
     parser.add_argument(
@@ -20,10 +22,12 @@ def main():
     )
     args = parser.parse_args()
 
+    stem = args.file_path.stem
+
     scraping = ScrapingDataFrame(
         file_path=args.file_path,
         sem=1,
-        downloads_path=f"{args.downloads_path}/archivo_adjunto_sisai_{args.file_path.replace('.json','')}",
+        downloads_path=f"{args.downloads_path}/archivo_adjunto_sisai_{args.file_path.stem}",
     )
     scraping.main()
 


### PR DESCRIPTION
Este PR mejora el manejo de rutas para que no sea necesario poner el archivo `.json` en la carpeta `sisai`. En vez de eso se puede poner en cualquier lado y símplemente referenciarlo en la línea de comandos así:

```shell
$ PLAYWRIGHT_BROWSERS_PATH=0  python3 solicitudes.py Abraham/CAMPECHE/04_2012.json
```

Esto no modifica cómo se guardan los archivos.